### PR TITLE
Add VStack renderable item culling tests

### DIFF
--- a/ComposeUI/Tests/ComposeUITests/ComposeNodes/VerticalStackNodeTests.swift
+++ b/ComposeUI/Tests/ComposeUITests/ComposeNodes/VerticalStackNodeTests.swift
@@ -238,4 +238,45 @@ class VerticalStackNodeTests: XCTestCase {
       expect(items[1].frame) == CGRect(x: 10, y: 50, width: 20, height: 20)
     }
   }
+
+  func test_renderableItems_filtersOffscreenChildren() {
+    var node = VStack {
+      LayerNode().frame(width: 10, height: 10)
+      LayerNode().frame(width: 10, height: 10)
+      LayerNode().frame(width: 10, height: 10)
+    }
+
+    let context = ComposeNodeLayoutContext(scaleFactor: 1)
+    _ = node.layout(containerSize: CGSize(width: 10, height: 30), context: context)
+
+    let items = node.renderableItems(in: CGRect(x: 0, y: 0, width: 10, height: 10))
+
+    guard items.count == 1 else {
+      fail("Expected 1 item")
+      return
+    }
+
+    expect(items[0].frame) == CGRect(x: 0, y: 0, width: 10, height: 10)
+  }
+
+  func test_renderableItems_includesOffsetChildren() {
+    var node = VStack {
+      LayerNode().frame(width: 10, height: 10)
+      LayerNode().frame(width: 10, height: 10)
+        .offset(x: 0, y: -10)
+    }
+
+    let context = ComposeNodeLayoutContext(scaleFactor: 1)
+    _ = node.layout(containerSize: CGSize(width: 10, height: 20), context: context)
+
+    let items = node.renderableItems(in: CGRect(x: 0, y: 0, width: 10, height: 10))
+
+    guard items.count == 2 else {
+      fail("Expected 2 items")
+      return
+    }
+
+    expect(items[0].frame) == CGRect(x: 0, y: 0, width: 10, height: 10)
+    expect(items[1].frame) == CGRect(x: 0, y: 0, width: 10, height: 10)
+  }
 }


### PR DESCRIPTION
### Motivation
- Verify `VStack`/`VerticalStackNode` correctly culls children outside the visible bounds and still includes children that are visible due to an `offset`.

### Description
- Added two unit tests to `Tests/ComposeUITests/ComposeNodes/VerticalStackNodeTests.swift`: `test_renderableItems_filtersOffscreenChildren` and `test_renderableItems_includesOffsetChildren` that exercise `renderableItems(in:)` behavior with `LayerNode` children.
- Each test calls `layout(containerSize:context:)` on a `VStack` with fixed child frames and then asserts the frames returned by `renderableItems(in:)` match the expected visible items.

### Testing
- No automated tests were executed as part of this change; the new unit tests were added but not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975264b0a988329b6a0607182198b79)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds targeted coverage for `VStack` visibility culling in `renderableItems(in:)`.
> 
> - Adds `test_renderableItems_filtersOffscreenChildren` and `test_renderableItems_includesOffsetChildren` in `Tests/ComposeUITests/ComposeNodes/VerticalStackNodeTests.swift`
> - Verifies `renderableItems(in:)` returns only visible `LayerNode` items, culling offscreen children and including children visible due to `.offset(...)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5d13e967e27a6c2db5710a4b92fcba11e5f9c18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->