### PR TITLE
Add HStack renderable item culling tests

### DIFF
--- a/ComposeUI/Tests/ComposeUITests/ComposeNodes/HorizontalStackNodeTests.swift
+++ b/ComposeUI/Tests/ComposeUITests/ComposeNodes/HorizontalStackNodeTests.swift
@@ -238,4 +238,45 @@ class HorizontalStackNodeTests: XCTestCase {
       expect(items[1].frame) == CGRect(x: 50, y: 10, width: 20, height: 20)
     }
   }
+
+  func test_renderableItems_filtersOffscreenChildren() {
+    var node = HStack {
+      LayerNode().frame(width: 10, height: 10)
+      LayerNode().frame(width: 10, height: 10)
+      LayerNode().frame(width: 10, height: 10)
+    }
+
+    let context = ComposeNodeLayoutContext(scaleFactor: 1)
+    _ = node.layout(containerSize: CGSize(width: 30, height: 10), context: context)
+
+    let items = node.renderableItems(in: CGRect(x: 0, y: 0, width: 10, height: 10))
+
+    guard items.count == 1 else {
+      fail("Expected 1 item")
+      return
+    }
+
+    expect(items[0].frame) == CGRect(x: 0, y: 0, width: 10, height: 10)
+  }
+
+  func test_renderableItems_includesOffsetChildren() {
+    var node = HStack {
+      LayerNode().frame(width: 10, height: 10)
+      LayerNode().frame(width: 10, height: 10)
+        .offset(x: -10, y: 0)
+    }
+
+    let context = ComposeNodeLayoutContext(scaleFactor: 1)
+    _ = node.layout(containerSize: CGSize(width: 20, height: 10), context: context)
+
+    let items = node.renderableItems(in: CGRect(x: 0, y: 0, width: 10, height: 10))
+
+    guard items.count == 2 else {
+      fail("Expected 2 items")
+      return
+    }
+
+    expect(items[0].frame) == CGRect(x: 0, y: 0, width: 10, height: 10)
+    expect(items[1].frame) == CGRect(x: 0, y: 0, width: 10, height: 10)
+  }
 }


### PR DESCRIPTION
### Motivation
- Bring `HStack` test coverage in line with `VStack` by verifying `renderableItems(in:)` correctly culls offscreen children and includes children that are moved into the query rect via `offset`.

### Description
- Added two tests to `ComposeUI/Tests/ComposeUITests/ComposeNodes/HorizontalStackNodeTests.swift`: `test_renderableItems_filtersOffscreenChildren` and `test_renderableItems_includesOffsetChildren`.
- `test_renderableItems_filtersOffscreenChildren` lays out a 3-child `HStack` and asserts that only the child overlapping the query rect is returned by `renderableItems(in:)`.
- `test_renderableItems_includesOffsetChildren` applies an `offset` to a child and asserts the offset child is included when its frame intersects the query rect.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756ca44af4832980927415986d105a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `HStack` coverage for `renderableItems(in:)` behavior.
> 
> - Adds `test_renderableItems_filtersOffscreenChildren` to ensure only overlapping children are returned
> - Adds `test_renderableItems_includesOffsetChildren` to ensure offset children intersecting the query rect are included
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 543de0d10013f1de2b018562eab0ae1f80d94766. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->